### PR TITLE
fix: LayoutDirection::Horizontal needs to be accounted for in render_…

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -194,7 +194,7 @@ impl<'a, V: NodeValue> TreeWidget<'a, V> {
             }
             _ => indent_size,
         };
-        let width: usize = area.width as usize;
+        let width: usize = (area.width + area.x) as usize;
         // Write indentation
         let (start_x, start_y) = buf.set_stringn(
             area.x,
@@ -302,7 +302,12 @@ mod test {
     use crate::mock::mock_tree;
 
     use pretty_assertions::assert_eq;
-    use tuirealm::ratatui::style::Color;
+    use tuirealm::ratatui::{
+        backend::TestBackend,
+        layout::{Constraint, Direction as LayoutDirection, Layout},
+        style::Color,
+        Terminal,
+    };
 
     #[test]
     fn should_construct_default_widget() {
@@ -359,5 +364,56 @@ mod test {
         let widget = TreeWidget::new(&tree);
         // 20th element - height (12) + 1
         assert_eq!(widget.calc_rows_to_skip(&state, 8), 13);
+    }
+
+    #[test]
+    fn should_not_panic_per_layout_direction() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let tree = mock_tree();
+        let constraints = [[50, 50], [100, 0]];
+        for direction in [LayoutDirection::Vertical, LayoutDirection::Horizontal] {
+            for constraint in constraints {
+                let widget = TreeWidget::new(&tree);
+                terminal
+                    .draw(|frame| {
+                        let layout = Layout::default()
+                            .direction(direction)
+                            .constraints(Constraint::from_percentages(constraint))
+                            .split(frame.area());
+                        frame.render_widget(widget, layout[1])
+                    })
+                    .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn should_not_panic_when_layout_nested() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let tree = mock_tree();
+        let constraints = [[50, 50], [100, 0]];
+        let directions = [LayoutDirection::Vertical, LayoutDirection::Horizontal];
+        for outer_direction in directions {
+            for inner_direction in directions {
+                for outer_constraint in constraints {
+                    for inner_constraint in constraints {
+                        let widget = TreeWidget::new(&tree);
+                        terminal
+                            .draw(|frame| {
+                                let layout = Layout::default()
+                                    .direction(outer_direction)
+                                    .constraints(Constraint::from_percentages(outer_constraint))
+                                    .split(frame.area());
+                                let nested_layout = Layout::default()
+                                    .direction(inner_direction)
+                                    .constraints(inner_constraint)
+                                    .split(layout[1]);
+                                frame.render_widget(widget, nested_layout[1])
+                            })
+                            .unwrap();
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #11 

Added some tests to make sure various combinations of layout direction, constraints, and nesting don't panic. 
Also visually tested this, but ratatui suggests using the `insta` crate to snapshot the rendered TUI state to the TestBackend and assert that: https://ratatui.rs/recipes/testing/snapshots/#_top

---

## Description

TreeWidget.render_node subtract with overflow

## Steps to reproduce

Cloned main, I just changed the example like so (make layout horizontal, 50/50, and make the tree the rightmost chunk

```rust
    fn view(&mut self) {
        let _ = self.terminal.raw_mut().draw(|f| {
            // Prepare chunks
            let chunks = Layout::default()
                .direction(LayoutDirection::Horizontal)
                .margin(1)
                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
                .split(f.area());
            self.app.view(&Id::FsTree, f, chunks[1]);
            self.app.view(&Id::GoTo, f, chunks[0]);
        });
    }

```

Error:
```
cargo run --example demo
   Compiling tui-realm-treeview v2.0.0 (/home/larry/code/tui-realm-treeview)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.64s
     Running `target/debug/examples/demo`
thread 'main' panicked at /home/larry/code/tui-realm-treeview/src/widget.rs:218:57:
attempt to subtract with overflow
```

Issue in `render_node`:
```rust
        // Write highlight symbol
        let (start_x, start_y) = highlight_symbol
            .map(|x| buf.set_stringn(start_x, start_y, x, width - start_x as usize, style))
            .map(|(x, y)| buf.set_stringn(x, y, " ", width - start_x as usize, style))
            .unwrap_or((start_x, start_y));

```
The issue is `width - start_x as usize`

## Expected behaviour

The tree should render in any layout.

## Environment

- Linux 6.8.0-51-generic #52-Ubuntu x86_64
- rustc 1.84.0 (9fc6b4312 2025-01-07)
- tui-realm-treeview version "2"

## Additional information

Thank you for tuirealm! You are a boss.

