### PR TITLE
Remove some Allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,7 @@ repository = "https://github.com/veeso/tui-realm-treeview"
 
 [dependencies]
 orange-trees = "0.1.0"
-<<<<<<< optimize
-tuirealm = { version = "2.1.0", default-features = false, features = ["derive"] }
-=======
 tuirealm = { version = "3", default-features = false, features = ["derive"] }
->>>>>>> main
 unicode-width = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/veeso/tui-realm-treeview"
 
 [dependencies]
 orange-trees = "0.1.0"
-tuirealm = { version = "2", default-features = false, features = ["derive"] }
+tuirealm = { version = "2.1.0", default-features = false, features = ["derive"] }
 unicode-width = "0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,8 +549,8 @@ impl<V: NodeValue> MockComponent for TreeView<V> {
                         .bg(background)
                         .add_modifier(modifiers),
                 );
-            if let Some(hg_str) = hg_str {
-                tree = tree.highlight_symbol(hg_str);
+            if let Some(hg_str) = &hg_str {
+                tree = tree.highlight_symbol(hg_str.as_str());
             }
             let mut state = self.states.clone();
             frame.render_stateful_widget(tree, area, &mut state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,8 +527,8 @@ impl<V: NodeValue> MockComponent for TreeView<V> {
             .add_modifier(modifiers);
             let hg_str = self
                 .props
-                .get(Attribute::HighlightedStr)
-                .map(|x| x.unwrap_string());
+                .get_ref(Attribute::HighlightedStr)
+                .and_then(|x| x.as_string());
             let div = Self::get_block(borders, title, focus, inactive_style);
             // Make widget
             let mut tree = TreeWidget::new(self.tree())
@@ -541,7 +541,7 @@ impl<V: NodeValue> MockComponent for TreeView<V> {
                         .bg(background)
                         .add_modifier(modifiers),
                 );
-            if let Some(hg_str) = &hg_str {
+            if let Some(hg_str) = hg_str {
                 tree = tree.highlight_symbol(hg_str.as_str());
             }
             let mut state = self.states.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,22 +334,16 @@ impl<V: NodeValue> TreeView<V> {
     /// ### title
     ///
     /// Set widget title
-    pub fn title<S: AsRef<str>>(mut self, t: S, a: Alignment) -> Self {
-        self.attr(
-            Attribute::Title,
-            AttrValue::Title((t.as_ref().to_string(), a)),
-        );
+    pub fn title<S: Into<String>>(mut self, t: S, a: Alignment) -> Self {
+        self.attr(Attribute::Title, AttrValue::Title((t.into(), a)));
         self
     }
 
     /// ### highlight_symbol
     ///
     /// Set symbol to prepend to highlighted node
-    pub fn highlight_symbol<S: AsRef<str>>(mut self, symbol: S) -> Self {
-        self.attr(
-            Attribute::HighlightedStr,
-            AttrValue::String(symbol.as_ref().to_string()),
-        );
+    pub fn highlight_symbol<S: Into<String>>(mut self, symbol: S) -> Self {
+        self.attr(Attribute::HighlightedStr, AttrValue::String(symbol.into()));
         self
     }
 
@@ -365,10 +359,10 @@ impl<V: NodeValue> TreeView<V> {
     ///
     /// Set initial node for tree state.
     /// NOTE: this must be specified after `with_tree`
-    pub fn initial_node<S: AsRef<str>>(mut self, node: S) -> Self {
+    pub fn initial_node<S: Into<String>>(mut self, node: S) -> Self {
         self.attr(
             Attribute::Custom(TREE_INITIAL_NODE),
-            AttrValue::String(node.as_ref().to_string()),
+            AttrValue::String(node.into()),
         );
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,13 +455,12 @@ impl<V: NodeValue> TreeView<V> {
         }
     }
 
-    fn get_block<'a>(
+    fn get_block(
         props: Borders,
-        title: Option<(String, Alignment)>,
+        title: (&str, Alignment),
         focus: bool,
         inactive_style: Option<Style>,
-    ) -> Block<'a> {
-        let title = title.unwrap_or((String::default(), Alignment::Left));
+    ) -> Block<'_> {
         Block::default()
             .borders(props.sides)
             .border_style(match focus {
@@ -497,11 +496,10 @@ impl<V: NodeValue> MockComponent for TreeView<V> {
                 .unwrap_text_modifiers();
             let title = self
                 .props
-                .get_or(
-                    Attribute::Title,
-                    AttrValue::Title((String::default(), Alignment::Center)),
-                )
-                .unwrap_title();
+                .get_ref(Attribute::Title)
+                .and_then(|v| v.as_title())
+                .map(|v| (v.0.as_str(), v.1))
+                .unwrap_or(("", Alignment::Center));
             let borders = self
                 .props
                 .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
@@ -531,7 +529,7 @@ impl<V: NodeValue> MockComponent for TreeView<V> {
                 .props
                 .get(Attribute::HighlightedStr)
                 .map(|x| x.unwrap_string());
-            let div = Self::get_block(borders, Some(title), focus, inactive_style);
+            let div = Self::get_block(borders, title, focus, inactive_style);
             // Make widget
             let mut tree = TreeWidget::new(self.tree())
                 .block(div)

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -131,10 +131,10 @@ impl TreeState {
                     } else {
                         // Then the next element becomes the next sibling of the parent
                         // this thing has to be performed recursively for all parents, until one is found (or root is reached)
-                        let mut current = selected.clone();
+                        let mut current = &selected;
                         loop {
-                            if let Some(parent) = root.parent(&current) {
-                                current = parent.id().to_string();
+                            if let Some(parent) = root.parent(current) {
+                                current = parent.id();
                                 if let Some(sibling) = self.next_sibling(root, parent) {
                                     self.selected = Some(sibling.id().to_string());
                                     break;

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -276,7 +276,7 @@ impl TreeState {
     ///
     /// Force open nodes
     pub fn force_open(&mut self, open: &[&str]) {
-        self.open = open.into_iter().map(|x| x.to_string()).collect();
+        self.open = open.iter().map(|x| x.to_string()).collect();
     }
 }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -93,14 +93,14 @@ struct Render {
     skip_rows: usize,
 }
 
-impl<'a, V: NodeValue> Widget for TreeWidget<'a, V> {
+impl<V: NodeValue> Widget for TreeWidget<'_, V> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let mut state = TreeState::default();
         StatefulWidget::render(self, area, buf, &mut state);
     }
 }
 
-impl<'a, V: NodeValue> StatefulWidget for TreeWidget<'a, V> {
+impl<V: NodeValue> StatefulWidget for TreeWidget<'_, V> {
     type State = TreeState;
 
     fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
@@ -128,7 +128,7 @@ impl<'a, V: NodeValue> StatefulWidget for TreeWidget<'a, V> {
     }
 }
 
-impl<'a, V: NodeValue> TreeWidget<'a, V> {
+impl<V: NodeValue> TreeWidget<'_, V> {
     fn iter_nodes(
         &self,
         node: &Node<V>,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -23,7 +23,7 @@ pub struct TreeWidget<'a, V: NodeValue> {
     /// Highlight style
     highlight_style: Style,
     /// Symbol to display on the side of the current highlighted
-    highlight_symbol: Option<String>,
+    highlight_symbol: Option<&'a str>,
     /// Spaces to use for indentation
     indent_size: usize,
     /// Tree to render
@@ -72,7 +72,7 @@ impl<'a, V: NodeValue> TreeWidget<'a, V> {
     /// ### highlight_symbol
     ///
     /// Set symbol to prepend to highlighted entry
-    pub fn highlight_symbol(mut self, s: String) -> Self {
+    pub fn highlight_symbol(mut self, s: &'a str) -> Self {
         self.highlight_symbol = Some(s);
         self
     }
@@ -169,7 +169,7 @@ impl<V: NodeValue> TreeWidget<'_, V> {
             return area;
         }
         let highlight_symbol = match state.is_selected(node) {
-            true => Some(self.highlight_symbol.clone().unwrap_or_default()),
+            true => Some(self.highlight_symbol.unwrap_or_default()),
             false => None,
         };
         // Get area for current node
@@ -190,7 +190,7 @@ impl<V: NodeValue> TreeWidget<'_, V> {
         let indent_size = render.depth * self.indent_size;
         let indent_size = match state.is_selected(node) {
             true if highlight_symbol.is_some() => {
-                indent_size.saturating_sub(highlight_symbol.as_deref().unwrap().width() + 1)
+                indent_size.saturating_sub(highlight_symbol.unwrap().width() + 1)
             }
             _ => indent_size,
         };
@@ -321,13 +321,13 @@ mod test {
         let widget = TreeWidget::new(&tree)
             .block(Block::default())
             .highlight_style(Style::default().fg(Color::Red))
-            .highlight_symbol(String::from(">"))
+            .highlight_symbol(">")
             .indent_size(8)
             .style(Style::default().fg(Color::LightRed));
         assert!(widget.block.is_some());
         assert_eq!(widget.highlight_style.fg.unwrap(), Color::Red);
         assert_eq!(widget.indent_size, 8);
-        assert_eq!(widget.highlight_symbol.as_deref().unwrap(), ">");
+        assert_eq!(widget.highlight_symbol.unwrap(), ">");
         assert_eq!(widget.style.fg.unwrap(), Color::LightRed);
     }
 


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

Requires the following to be merged and released:
- https://github.com/veeso/tui-realm/pull/88
- https://github.com/veeso/tui-realm/pull/89
- https://github.com/veeso/tui-realm/pull/91

## Description

This PR mainly removes allocations with the help of the above mentioned PRs, also does some extra things. In more details:
- fix initial style issues
- change "AsRef<str>" taking functions to "Into<String>" to avoid having to create a new string, if one already exists (potentially breaking change)
- change `get_block` to not take a option, as it is only called in one place, which is already defaulted
- change `TreeWidget::highlight_symbol` to be a `&str` instead of a String

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
