### PR TITLE
fix(tree_state::get_last_open_heir): should not panic if the node is open, but does not have any children

### DIFF
--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -220,7 +220,11 @@ impl TreeState {
     fn get_last_open_heir<'a, V>(&self, node: &'a Node<V>) -> &'a Node<V> {
         if self.is_open(node) {
             // If node is open, get its last child and call this function recursively
-            self.get_last_open_heir(node.iter().last().unwrap())
+            if let Some(child) = node.iter().last() {
+                self.get_last_open_heir(child)
+            } else {
+                node
+            }
         } else {
             // Else return `node`
             node
@@ -594,5 +598,23 @@ mod test {
                 .as_str(),
             "aC0"
         );
+    }
+
+    #[test]
+    fn get_last_open_heir_0_children() {
+        let mut state = TreeState::default();
+        let mut tree = mock_tree();
+
+        state.select(tree.root(), tree.root());
+        state.open(tree.root());
+
+        let node = &tree.root().children()[0];
+        let node_id = node.id().to_string();
+        state.select(tree.root(), node);
+        state.open(tree.root());
+
+        tree.root_mut().query_mut(&node_id).unwrap().clear();
+
+        state.get_last_open_heir(&tree.root().children()[0]);
     }
 }


### PR DESCRIPTION
# ISSUE _NUMBER_ - PULL_REQUEST_TITLE

fixes #15

## Description

Fix the panic by falling back to the current node.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
